### PR TITLE
chore: Implement IConnectorV2 interfaces, and mark old classes as obsolete

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
-    <_CluedIn>3.6.0-beta.69</_CluedIn>
+    <_CluedIn>3.6.0-*</_CluedIn>
   </PropertyGroup>
   <ItemGroup>
     <!--

--- a/Packages.props
+++ b/Packages.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
-    <_CluedIn>3.5.3</_CluedIn>
+    <_CluedIn>3.6.0-beta.69</_CluedIn>
   </PropertyGroup>
   <ItemGroup>
     <!--

--- a/src/Connector.Common/Clients/ITransactionalClientBaseV2.cs
+++ b/src/Connector.Common/Clients/ITransactionalClientBaseV2.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Data;
+using System.Threading.Tasks;
+
+namespace CluedIn.Connector.Common.Clients
+{
+    public interface ITransactionalClientBaseV2<TConnection, TTransaction, TParameter>
+        where TConnection : IDbConnection
+        where TTransaction : IDbTransaction
+        where TParameter : IDbDataParameter
+    {
+        Task ExecuteCommandInTransactionAsync(TTransaction transaction, string commandText, IEnumerable<TParameter> param = null);
+        Task<ConnectionAndTransaction<TConnection, TTransaction>> BeginTransaction(IReadOnlyDictionary<string, object> config);
+        Task<DataTable> GetTableColumns(TTransaction transaction, string tableName, string schema = null);
+        Task<DataTable> GetTables(TTransaction transaction, string name = null, string schema = null);
+    }
+}

--- a/src/Connector.Common/Clients/TransactionalClientBaseV2.cs
+++ b/src/Connector.Common/Clients/TransactionalClientBaseV2.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Data;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CluedIn.Connector.Common.Clients
+{
+    public abstract class TransactionalClientBaseV2<TConnection, TTransaction, TParameter> : ITransactionalClientBaseV2<TConnection, TTransaction, TParameter>
+        where TConnection : DbConnection, new()
+        where TTransaction : DbTransaction
+        where TParameter : IDbDataParameter
+    {
+        public async Task ExecuteCommandInTransactionAsync(TTransaction transaction, string commandText, IEnumerable<TParameter> param = null)
+        {
+            var cmd = transaction.Connection.CreateCommand();
+            cmd.CommandText = commandText;
+            cmd.Transaction = transaction;
+
+            if (param != null)
+            {
+                foreach (var parameter in param)
+                {
+                    ClientUtils.SanitizeParameter(parameter);
+                    cmd.Parameters.Add(parameter);
+                }
+            }
+
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public async Task<ConnectionAndTransaction<TConnection, TTransaction>> BeginTransaction(IReadOnlyDictionary<string, object> config)
+        {
+            var connectionString = BuildConnectionString(config);
+            var connection = Activator.CreateInstance(typeof(TConnection), connectionString) as TConnection;
+
+            // ReSharper disable once PossibleNullReferenceException
+            await connection.OpenAsync();
+            return new ConnectionAndTransaction<TConnection, TTransaction>(connection, await connection.BeginTransactionAsync() as TTransaction);
+        }
+
+        public async Task<DataTable> GetTableColumns(TTransaction transaction, string tableName, string schema = null)
+        {
+            return await ClientUtils.GetRestrictedSchema(transaction.Connection, "Columns", tableName, schema);
+        }
+
+        public async Task<DataTable> GetTables(TTransaction transaction, string name = null, string schema = null)
+        {
+            return await ClientUtils.GetRestrictedSchema(transaction.Connection, "Tables", name, schema);
+        }
+
+        public abstract string BuildConnectionString(IReadOnlyDictionary<string, object> config);
+    }
+}

--- a/src/Connector.Common/Connectors/CommonConnectorBase.cs
+++ b/src/Connector.Common/Connectors/CommonConnectorBase.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 
 namespace CluedIn.Connector.Common.Connectors
 {
+    [Obsolete("Use CommonConnectorBaseV2 instead.")]
     public abstract class CommonConnectorBase<TConnector, TClient> : ConnectorBase
         where TConnector : CommonConnectorBase<TConnector, TClient>
     {

--- a/src/Connector.Common/Connectors/CommonConnectorBaseV2.cs
+++ b/src/Connector.Common/Connectors/CommonConnectorBaseV2.cs
@@ -1,0 +1,58 @@
+﻿using CluedIn.Core;
+using CluedIn.Core.Connectors;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace CluedIn.Connector.Common.Connectors
+{
+    public abstract class CommonConnectorBaseV2<TConnector, TClient> : ConnectorBaseV2
+        where TConnector : CommonConnectorBaseV2<TConnector, TClient>
+    {
+        protected readonly TClient _client;
+        protected readonly ILogger<TConnector> _logger;
+
+        protected CommonConnectorBaseV2(ILogger<TConnector> logger, TClient client, Guid providerId, bool supportsRetrievingLatestEntityPersistInfo)
+            : base(providerId, supportsRetrievingLatestEntityPersistInfo)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+        }
+
+        protected string GetCodesContainerName(string containerName) => $"{containerName}Codes";
+        protected string GetIncomingEdgesContainerName(string containerName) => $"{containerName}IncomingEdges";
+        protected string GetIncomingEdgesPropertiesContainerName(string containerName) => $"{containerName}IncomingEdgesProperties";
+        protected string GetOutgoingEdgesContainerName(string containerName) => $"{containerName}OutgoingEdges";
+        protected string GetOutgoingEdgesPropertiesContainerName(string containerName) => $"{containerName}OutgoingEdgesProperties";
+
+        /// <summary>
+        ///     Strip non-alpha numeric characters
+        /// </summary>
+        public override Task<string> GetValidMappingDestinationPropertyName(ExecutionContext executionContext, Guid connectorProviderDefinitionId, string containerName)
+        {
+            return Task.FromResult(Regex.Replace(containerName, @"[^A-Za-z0-9]+", ""));
+        }
+
+        protected virtual async Task<string> GetValidContainerName(ExecutionContext executionContext, Guid connectorProviderDefinitionId, string containerName, Func<ExecutionContext, Guid, string, Task<bool>> checkTableExistPredicate)
+        {
+            // Strip non-alpha numeric characters
+            var cleanName = Regex.Replace(containerName, @"[^A-Za-z0-9]+", "");
+
+            if (!await checkTableExistPredicate(executionContext, connectorProviderDefinitionId, cleanName))
+                return cleanName;
+
+            // If exists, append count like in windows explorer
+            var count = 0;
+            string newName;
+            do
+            {
+                count++;
+                newName = $"{cleanName}{count}";
+            } while (await checkTableExistPredicate(executionContext, connectorProviderDefinitionId, newName));
+
+            return newName;
+
+        }
+    }
+    }

--- a/src/Connector.Common/Connectors/CommonTransactionalConnectorBase.cs
+++ b/src/Connector.Common/Connectors/CommonTransactionalConnectorBase.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 
 namespace CluedIn.Connector.Common.Connectors
 {
+    [Obsolete("Use CommonTransactionalConnectorBaseV2 instead.")]
     public abstract class CommonTransactionalConnectorBase : ConnectorBase
     {
         protected CommonTransactionalConnectorBase(IConfigurationRepository configurationRepository, Guid providerId) : base(configurationRepository)

--- a/src/Connector.Common/Connectors/CommonTransactionalConnectorBaseV2.cs
+++ b/src/Connector.Common/Connectors/CommonTransactionalConnectorBaseV2.cs
@@ -1,0 +1,56 @@
+﻿using CluedIn.Core;
+using CluedIn.Core.Connectors;
+using System;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace CluedIn.Connector.Common.Connectors
+{
+    public abstract class CommonTransactionalConnectorBaseV2 : ConnectorBaseV2
+    {
+        protected CommonTransactionalConnectorBaseV2(Guid providerId, bool supportsRetrievingLatestEntityPersistInfo) : base(providerId, supportsRetrievingLatestEntityPersistInfo)
+        {
+        }
+
+        protected string GetCodesContainerName(string containerName) => $"{containerName}Codes";
+        protected string GetIncomingEdgesContainerName(string containerName) => $"{containerName}IncomingEdges";
+        protected string GetIncomingEdgesPropertiesContainerName(string containerName) => $"{containerName}IncomingEdgesProperties";
+        protected string GetOutgoingEdgesContainerName(string containerName) => $"{containerName}OutgoingEdges";
+        protected string GetOutgoingEdgesPropertiesContainerName(string containerName) => $"{containerName}OutgoingEdgesProperties";
+
+        /// <summary>
+        /// Strip non-alpha numeric characters
+        /// </summary>
+        public override Task<string> GetValidMappingDestinationPropertyName(
+            ExecutionContext executionContext,
+            Guid connectorProviderDefinitionId,
+            string name)
+        {
+            return Task.FromResult(Regex.Replace(name, @"[^A-Za-z0-9]+", ""));
+        }
+
+        protected virtual async Task<string> GetValidContainerName(
+            ExecutionContext executionContext,
+            Guid connectorProviderDefinitionId,
+            string containerName,
+            Func<ExecutionContext, Guid, string, Task<bool>> checkTableExistPredicate)
+        {
+            // Strip non-alpha numeric characters
+            var cleanName = Regex.Replace(containerName, @"[^A-Za-z0-9]+", "");
+
+            if (!await checkTableExistPredicate(executionContext, connectorProviderDefinitionId, cleanName))
+                return cleanName;
+
+            // If exists, append count like in windows explorer
+            var count = 0;
+            string newName;
+            do
+            {
+                count++;
+                newName = $"{cleanName}{count}";
+            } while (await checkTableExistPredicate(executionContext, connectorProviderDefinitionId, newName));
+
+            return newName;
+        }
+    }
+}

--- a/src/Connector.Common/Connectors/SqlConnectorBase.cs
+++ b/src/Connector.Common/Connectors/SqlConnectorBase.cs
@@ -1,17 +1,17 @@
 ﻿using CluedIn.Connector.Common.Clients;
 using CluedIn.Connector.Common.Helpers;
 using CluedIn.Core;
+using CluedIn.Core.Data;
 using CluedIn.Core.DataStore;
-using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.Common;
 using System.Threading.Tasks;
 
 namespace CluedIn.Connector.Common.Connectors
 {
+    [Obsolete("Use SqlConnectorBaseV2 instead.")]
     public abstract class SqlConnectorBase<TConnection, TTransaction, TParameter> : CommonTransactionalConnectorBase
         where TConnection : IDbConnection
         where TTransaction : IDbTransaction

--- a/src/Connector.Common/Connectors/SqlConnectorBaseV2.cs
+++ b/src/Connector.Common/Connectors/SqlConnectorBaseV2.cs
@@ -1,0 +1,109 @@
+﻿using CluedIn.Connector.Common.Clients;
+using CluedIn.Connector.Common.Helpers;
+using CluedIn.Core;
+using CluedIn.Core.Connectors;
+using CluedIn.Core.Data;
+using CluedIn.Core.DataStore;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CluedIn.Connector.Common.Connectors
+{
+    public abstract class SqlConnectorBaseV2<TConnection, TTransaction, TParameter> : CommonTransactionalConnectorBaseV2
+        where TConnection : IDbConnection
+        where TTransaction : IDbTransaction
+        where TParameter : IDbDataParameter
+    {
+        protected readonly ILogger<SqlConnectorBaseV2<TConnection, TTransaction, TParameter>> _logger;
+        private readonly ITransactionalClientBaseV2<TConnection, TTransaction, TParameter> _client;
+
+        protected SqlConnectorBaseV2(
+            ILogger<SqlConnectorBaseV2<TConnection, TTransaction, TParameter>> logger,
+            ITransactionalClientBaseV2<TConnection, TTransaction, TParameter> client,
+            Guid providerId,
+            bool supportsRetrievingLatestEntityPersistInfo)
+            : base(providerId, supportsRetrievingLatestEntityPersistInfo)
+        {
+            _logger = logger;
+            _client = client;
+        }
+
+        public override async Task<ConnectionVerificationResult> VerifyConnection(ExecutionContext executionContext, IReadOnlyDictionary<string, object> config)
+        {
+            try
+            {
+                await using var connectionAndTransaction = await _client.BeginTransaction(config);
+                var connectionIsOpen = connectionAndTransaction.Connection.State == ConnectionState.Open;
+                await connectionAndTransaction.DisposeAsync();
+
+                return new ConnectionVerificationResult(connectionIsOpen);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Error verifying connection");
+                return new ConnectionVerificationResult(false, e.Message);
+            }
+        }
+
+        public override Task<string> GetValidMappingDestinationPropertyName(ExecutionContext executionContext, Guid connectorProviderDefinitionId, string propertyName)
+        {
+            return Task.FromResult(SqlStringSanitizer.Sanitize(propertyName));
+        }
+
+        public Task<string> GetValidMappingDestinationPropertyName(string propertyName)
+        {
+            return Task.FromResult(SqlStringSanitizer.Sanitize(propertyName));
+        }
+
+        public override async Task<string> GetValidContainerName(ExecutionContext executionContext, Guid connectorProviderDefinitionId, string containerName)
+        {
+            ;
+            var config = await AuthenticationDetailsHelper.GetAuthenticationDetails(executionContext, connectorProviderDefinitionId);
+            await using var connectionAndTransaction = await _client.BeginTransaction(config.Authentication);
+            return await GetValidContainerNameInTransaction(executionContext, connectorProviderDefinitionId, connectionAndTransaction.Transaction, containerName);
+        }
+
+        public async Task<string> GetValidContainerNameInTransaction(ExecutionContext executionContext, Guid connectorProviderDefinitionId, TTransaction transaction, string containerName)
+        {
+            var cleanName = SqlStringSanitizer.Sanitize(containerName);
+
+            if (!await CheckTableExists(executionContext, connectorProviderDefinitionId, transaction, cleanName))
+                return cleanName;
+
+            // If exists, append count like in windows explorer
+            var count = 0;
+            string newName;
+            do
+            {
+                count++;
+                newName = $"{cleanName}{count}";
+            } while (await CheckTableExists(executionContext, connectorProviderDefinitionId, transaction, newName));
+
+            return newName;
+        }
+
+        protected virtual string BuildEmptyContainerSql(string tableName)
+        {
+            return $"TRUNCATE TABLE [{SqlStringSanitizer.Sanitize(tableName)}]";
+        }
+
+
+        protected virtual async Task<bool> CheckTableExists(ExecutionContext executionContext, Guid connectorProviderDefinitionId, TTransaction transaction, string name)
+        {
+            try
+            {
+                var tables = await _client.GetTables(transaction, name);
+
+                return tables.Rows.Count > 0;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Work Item ID: [AB#21158](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/21158)

Add implementations of `IConnectorV2`, and mark implementations of `IConnector` as obsolete
